### PR TITLE
Add synthmeat

### DIFF
--- a/Source/BadMeatCategory/BadMeatCategory.cs
+++ b/Source/BadMeatCategory/BadMeatCategory.cs
@@ -7,6 +7,15 @@ namespace BadMeatCategory;
 [StaticConstructorOnStartup]
 public class BadMeatCategory
 {
+    static List<string> GetExtraThingDefs()
+    {
+        return new List<string>
+        {
+            "Meat_Chaocow",
+            "MeatRotten"
+        };
+    }
+
     static BadMeatCategory()
     {
         var MeatRawCategory = DefDatabase<ThingCategoryDef>.GetNamedSilentFail("MeatRaw");
@@ -25,11 +34,7 @@ public class BadMeatCategory
             return;
         }
 
-        var extraThingDefs = new List<string>
-        {
-            "Meat_Chaocow",
-            "MeatRotten"
-        };
+        var extraThingDefs = GetExtraThingDefs();
         var thingsToMove = new List<ThingDef>();
         foreach (var descendantThingDef in MeatRawCategory.DescendantThingDefs)
         {

--- a/Source/BadMeatCategory/BadMeatCategory.cs
+++ b/Source/BadMeatCategory/BadMeatCategory.cs
@@ -12,7 +12,8 @@ public class BadMeatCategory
         return new List<string>
         {
             "Meat_Chaocow",
-            "MeatRotten"
+            "MeatRotten",
+            "Replimat_Synthmeat"
         };
     }
 


### PR DESCRIPTION
Adds Replimat's Synthmeat to the BadMeat category as it is explicitly for animals (humans get bad thoughts if they eat it).

Additionally, moves the list to a separate static method that can be easily postfix'd by other mods to add compatibility.