### PR TITLE
Move constructor to a separate class so main class can be patched

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -16,7 +16,7 @@
   <description>[img]https://i.imgur.com/buuPQel.png[/img]
 
 Puts all meat that is defined as coming from a Humanlike race and would cause bad thoughts from eating in its own category 
-Also moves meat from Insectoids, rotten meat from [url=https://steamcommunity.com/sharedfiles/filedetails/?id=2466790513]Rotten Meat[/url] and Chaomeat from [url=https://steamcommunity.com/sharedfiles/filedetails/?id=1786466855]Pawnmorpher[/url]
+Also moves meat from Insectoids, rotten meat from [url=https://steamcommunity.com/sharedfiles/filedetails/?id=2466790513]Rotten Meat[/url], Chaomeat from [url=https://steamcommunity.com/sharedfiles/filedetails/?id=1786466855]Pawnmorpher[/url], and Synthmeat from [url=https://steamcommunity.com/sharedfiles/filedetails/?id=1715402900]Replimat[/url]
 
 Russian translation by Tkhakiro
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # BadMeatCategory
-
+
+
 ![Image](https://i.imgur.com/buuPQel.png)
 
 
 Puts all meat that is defined as coming from a Humanlike race and would cause bad thoughts from eating in its own category 
-Also moves meat from Insectoids, rotten meat from https://steamcommunity.com/sharedfiles/filedetails/?id=2466790513]Rotten Meat and Chaomeat from https://steamcommunity.com/sharedfiles/filedetails/?id=1786466855]Pawnmorpher
+Also moves meat from Insectoids, rotten meat from [Rotten Meat](https://steamcommunity.com/sharedfiles/filedetails/?id=2466790513), Chaomeat from [Pawnmorpher](https://steamcommunity.com/sharedfiles/filedetails/?id=1786466855), and Synthmeat from [Replimat](https://steamcommunity.com/sharedfiles/filedetails/?id=1715402900)
 
 Russian translation by Tkhakiro
 
@@ -12,9 +13,9 @@ Idea by: Rasutei
 	
 ![Image](https://i.imgur.com/O0IIlYj.png)
 
-Since modding is just a hobby for me I expect no donations to keep modding. If you still want to show your support you can gift me anything from my https://store.steampowered.com/wishlist/id/Mlie]Wishlist or buy me a cup of tea.
+Since modding is just a hobby for me I expect no donations to keep modding. If you still want to show your support you can gift me anything from my [Wishlist](https://store.steampowered.com/wishlist/id/Mlie) or buy me a cup of tea.
 
-https://ko-fi.com/G2G55DDYD]![Image](https://i.imgur.com/Utx6OIH.png)
+[![Image](https://i.imgur.com/Utx6OIH.png)](https://ko-fi.com/G2G55DDYD)
 
 
 ![Image](https://i.imgur.com/PwoNOj4.png)
@@ -23,7 +24,7 @@ https://ko-fi.com/G2G55DDYD]![Image](https://i.imgur.com/Utx6OIH.png)
 
 -  See if the the error persists if you just have this mod and its requirements active.
 -  If not, try adding your other mods until it happens again.
--  Post your error-log using https://steamcommunity.com/workshop/filedetails/?id=818773962]HugsLib and command Ctrl+F12
+-  Post your error-log using [HugsLib](https://steamcommunity.com/workshop/filedetails/?id=818773962) and command Ctrl+F12
 -  For best support, please use the Discord-channel for error-reporting.
 -  Do not report errors by making a discussion-thread, I get no notification of that.
 -  If you have the solution for a problem, please post it to the GitHub repository.
@@ -31,4 +32,4 @@ https://ko-fi.com/G2G55DDYD]![Image](https://i.imgur.com/Utx6OIH.png)
 
 
 
-https://steamcommunity.com/sharedfiles/filedetails/changelog/2470221991]Last updated 2023-03-24
+[Last updated 2023-03-24](https://steamcommunity.com/sharedfiles/filedetails/changelog/2470221991)

--- a/Source/BadMeatCategory/BadMeatCategory.cs
+++ b/Source/BadMeatCategory/BadMeatCategory.cs
@@ -4,7 +4,6 @@ using Verse;
 
 namespace BadMeatCategory;
 
-[StaticConstructorOnStartup]
 public class BadMeatCategory
 {
     static List<string> GetExtraThingDefs()
@@ -17,7 +16,7 @@ public class BadMeatCategory
         };
     }
 
-    static BadMeatCategory()
+    internal static void SetupBadMeatCategory()
     {
         var MeatRawCategory = DefDatabase<ThingCategoryDef>.GetNamedSilentFail("MeatRaw");
         if (MeatRawCategory == null)

--- a/Source/BadMeatCategory/Startup.cs
+++ b/Source/BadMeatCategory/Startup.cs
@@ -1,0 +1,13 @@
+﻿using Verse;
+
+namespace BadMeatCategory
+{
+    [StaticConstructorOnStartup]
+    public class Startup
+    {
+        static Startup()
+        {
+            BadMeatCategory.SetupBadMeatCategory();
+        }
+    }
+}


### PR DESCRIPTION
I'm kind of an idiot for not actually testing a patch before sending the PR yesterday, but it obviously didn't work because there's a new PR

Basically, the method was impossible to patch because the class that contained `GetExtraThingDefs` was the one that had `[StaticConstructorOnStartup]` on it, meaning that the constructor ran (and moved the defs) as soon as patching was attempted, meaning that the patch applied but it didn't actually get called because the constructor had already run earlier...

So yeah, I moved the code that gets and moves the defs around to a separate static class. _That_ class can be safely patched, since it doesn't have a static constructor. Then, the new `Startup` class calls the new static method when _it's_ `[StaticConstructorOnStartup]` constructor executes.

As an apology, I offer an update of the README and About.xml? Sorry.

E: I want to say that I'm not normally this stupid, but to be honest, it's not that uncommon.